### PR TITLE
Bumping ruby version and fix workato-connector-sdk version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1
+FROM ruby:3.1.6
 
 ARG WORKATO_SDK_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM ruby:3.1.6
 
 ARG WORKATO_SDK_VERSION
 
-RUN gem install "workato-connector-sdk:${WORKATO_SDK_VERSION}"
+RUN gem install workato-connector-sdk -v ${WORKATO_SDK_VERSION}
 
 ENTRYPOINT ["workato"]


### PR DESCRIPTION
<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->

## Summary

Bumping Ruby version to 3.1.6 which is the latest release in the 3.1 series. Also fix the syntax for installing a specific version of workato-connector-sdk